### PR TITLE
fix(mixins-general): :wheelchair: fix accessibility issue with `scrol…

### DIFF
--- a/src/mixins/general/_reset.scss
+++ b/src/mixins/general/_reset.scss
@@ -56,7 +56,13 @@
     // * Set core root defaults
     html,
     html:focus-within {
-        scroll-behavior: smooth;
+        @media (prefers-reduced-motion: no-preference) {
+            scroll-behavior: smooth;
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+            scroll-behavior: auto;
+        }
     }
 
     // * Set core body defaults
@@ -184,10 +190,6 @@
     // * Remove all animations, transitions and smooth scroll for
     // * people that prefer not to see them
     @media (prefers-reduced-motion: reduce) {
-        html:focus-within {
-            scroll-behavior: smooth;
-        }
-
         *,
         *::before,
         *::after {


### PR DESCRIPTION
…l-behavior` prop in `reset` mixin

Add `prefers-reduced-motion` media query to `html, html:focus-within` to improve accessibility and prevent set the value of this prop to be `auto` when the value of media query `prefers-reduced-motion` is reduced.