### PR TITLE
feat(mixins-logical-props): :sparkles: add `right` mixin with its con…

### DIFF
--- a/src/mixins/logical-props/_index.scss
+++ b/src/mixins/logical-props/_index.scss
@@ -61,3 +61,8 @@
 // * This module likely contains bottom logical props.
 // @see bottom
 @forward "./bottom";
+
+// * forwarding the "right" module.
+// * This module likely contains right logical props.
+// @see right
+@forward "./right";

--- a/src/mixins/logical-props/_right.scss
+++ b/src/mixins/logical-props/_right.scss
@@ -1,0 +1,63 @@
+@charset "UTF-8";
+
+// @description
+// * right mixin.
+// * This mixin generates CSS logical properties for right property.
+// * It will generate right & inset-inline-end properties.
+
+// @access public
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/ZexLabs/sass-pire
+
+// @namespace logical-props
+
+// @module logical-props/right
+
+// @dependencies:
+// * - meta.type-of (SASS function).
+// * - math.unit (SASS function).
+// * - list.index (SASS function).
+// * - var.var.$all-units (variable).
+// * - Error.toggle (function).
+
+// @example
+// * .example {
+// *   @include right(2rem);
+// * }
+
+// @output
+// * .example {
+// *    inset-inline-end: 2rem;
+// *    right: 2rem;
+// * }
+
+@use "sass:meta";
+@use "sass:list";
+@use "sass:math";
+@use "../../abstract/global-variables" as var;
+@use "../../development-utils/toggle-error-message" as Error;
+
+@mixin right($value: 0) {
+    @if meta.type-of($value) != number {
+        content: Error.toggle("The parameter of right mixin must be in a number type.");
+    } @else {
+        $get-unit: math.unit($value);
+
+        @if $get-unit != "" {
+            @if list.index(var.$all-units, $get-unit) {
+                inset-inline-end: $value;
+                right: $value;
+            } @else {
+                content: Error.toggle("The parameter of right mixin must be one of these values: (#{var.$all-units}).");
+            }
+        } @else {
+            content: Error.toggle("The parameter of right mixin must have a unit.");
+        }
+    }
+}


### PR DESCRIPTION
…tent

<!-- Please, complete this template with the required information -->

## Issue | Task Number: #
None

## What does this pull request do?
This PR adds a new mixin to use `right` CSS property with logical property.

## What is the relevant issue link:
None

## Screenshot (if applicable)
None

## Any additional information?
None
